### PR TITLE
foomatic-ppdfile: add `export` subcommand to generate all ppd files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-10-24 Yarny0 <41838844+Yarny0@users.noreply.github.com>
+
+	* foomatic-ppdfile.in: Add "export" subcommand
+	  to permit generating many or all ppd files.
+
 2020-01-31 Till Kamppeter <till.kamppeter@gmail.com>
 
 	* lib/Foomatic/DB.pm: Allow non-integer numbers in the "PageSize"

--- a/foomatic-ppdfile.in
+++ b/foomatic-ppdfile.in
@@ -181,6 +181,52 @@ sub foomaticlistppds {
     }
 }
 
+sub ppd_text_from_poid_and_driver {
+
+    my ($db, $poid, $driver) = @_;
+
+    # We expect this function to be called with a real driver name
+    die "ERROR: $progname: bad driver '$driver' for printer '$poid'\n"  if (!$driver || ($driver =~ /(default|recommended)/i));
+
+    my @drvlist = $db->get_drivers_for_printer($poid, 1);
+    my $found = 0;
+    if (@drvlist) {
+	for my $d (@drvlist) {
+	    last if ($found = ($driver eq $d));
+	}
+	warn "ERROR: $progname: Printer '$poid' and driver '$driver' are not compatible\n" if (!$found);
+    }
+    $found = 0;
+    for my $d (@drivers) {
+        last if ($found = ($driver eq $d));
+    }
+    print STDERR "DEBUG: $progname: Driver '$driver' not in database!\n" if (!$found) and $debug;
+
+    # Get all the data about this driver/printer pair,
+    # stop if the printer is not supported by the given driver
+    if (!$db->getdat($driver, $poid)) {
+        warn "ERROR: $progname: The printer '$poid' is not supported by the driver '$driver':\n$db->{'log'}";
+        return;
+    }
+
+    # Stop if the driver entry has an empty command line prototype or if there
+    # is no custom PPD file
+    if ((!$db->{'dat'}{'cmd'}) && (!$db->{'dat'}{'ppdfile'})) {
+        warn "ERROR: $progname: There is neither a custom PPD file nor the driver database entry contains sufficient data to build a PPD file.\n";
+        return;
+    }
+
+    my @data = $db->getppd($opt_w);
+
+    if (!@data) {
+        warn "ERROR: $progname: No PPD file for printer '$poid' and driver '$driver'!\n";
+        return;
+    }
+
+    return @data;
+
+}
+
 sub generateppd {
 
     my ($ppduri, $driver) = @_;
@@ -235,42 +281,9 @@ sub generateppd {
 	    die "ERROR: $progname: Printer '$poid' does not have default driver!\n";
 	}
     }
-    
-    my @drvlist = $db->get_drivers_for_printer($poid, 1);
-    my $found = 0;
-    if(@drvlist) {
-	for my $d (@drvlist) {
-	    last if ($found = ($driver eq $d));
-	}
-	if ( not $found ) {
-	    warn "ERROR: $progname: Printer '$poid' and driver '$driver' are not compatible\n";
-	}
-    }
-    $found = 0;
-    for my $d (@drivers) {
-        last if ($found = ($driver eq $d));
-    }
-    if ( not $found ) {
-        print STDERR "DEBUG: $progname: Driver '$driver' not in database!\n" if $debug;
-    }
 
-    # Get all the data about this driver/printer pair
-    my $possible = $db->getdat($driver, $poid);
-    
-    # Stop if the printer is not supported by the given driver
-    die $db->{'log'} if (!$possible);
-    
-    # Stop if the driver entry has an empty command line prototype or if there 
-    # is no custom PPD file
-    die "ERROR: $progname: There is neither a custom PPD file nor the driver database entry contains sufficient data to build a PPD file.\n"
-	if (!$db->{'dat'}{'cmd'}) && (!$db->{'dat'}{'ppdfile'});
-    
-    my @data;
-
-    @data = $db->getppd($opt_w);
-    die "ERROR: $progname: No PPD file for printer '$poid' and driver '$driver'!\n"
-	if not @data;
-
+    @data = ppd_text_from_poid_and_driver($db, $poid, $driver);
+    die  if (!@data);
     print @data;
 
 }

--- a/foomatic-ppdfile.in
+++ b/foomatic-ppdfile.in
@@ -37,14 +37,20 @@ my $onlyrecommended = 0;
 # /etc/cups/foomatic.conf
 my $listreadymadeppds = 0;
 help() if !@ARGV;
-#my ($opt_h, $opt_d, $opt_p, $opt_A, $opt_P, $opt_w);
-getopts("AP:d:p:hwt:");
+#my ($opt_h, $opt_d, $opt_p, $opt_N, $opt_A, $opt_P, $opt_w);
+getopts("AP:d:p:N:hwt:");
 help() if $opt_h;
 my $drv = $opt_d;
 my $poid   = $opt_p;
 my $showall   = $opt_A;
 my $showmatch   = $opt_P;
-help() if ($#ARGV > 1) && !($poid);
+help() if ($#ARGV > 1) && !($poid) && !($ARGV[0] =~ /^export$/i);
+
+# We need the MCE module only if the '-N' option is used
+if ($opt_N) {
+    require MCE;
+    MCE->import;
+}
 
 if ($ARGV[0] =~ /^list$/i) {
     # List all available PPD files (format for cups-driverd)
@@ -52,6 +58,9 @@ if ($ARGV[0] =~ /^list$/i) {
 } elsif ($ARGV[0] =~ /^cat$/i) {
     # Generate and return the selected PPD file (cups-driverd command line)
     generateppd($ARGV[1]);
+} elsif ($ARGV[0] =~ /^export$/i) {
+    # Generate and save all PPD files
+    exportppds($showmatch);
 } elsif ($showall or $showmatch) {
     # List all PPD files or files matching regexp (manual operation)
     foomaticlistppds($showmatch);
@@ -288,6 +297,73 @@ sub generateppd {
 
 }
 
+sub export_ppds_for_printer {
+
+    my ($db, $onlyrecommended, $match, $printer) = @_;
+
+    my $poid = $printer->{'id'};
+    my $model = $printer->{'model'};
+    my $pr = $printer->{'make'};
+    my $recdriver = $printer->{'driver'};
+
+    # we skip unmatching printers here to simplify
+    # the for-loop code in the calling function
+    return  if ($match and not ("$pr $model" =~ m{$match}o));
+
+    my @drivers = ();
+    if (!$onlyrecommended) {
+        push (@drivers, @{$printer->{'drivers'}});
+    } elsif (Foomatic::DB::member($recdriver, @{$printer->{'drivers'}})) {
+        push (@drivers, $recdriver);
+    } # else: no (valid) recommended driver => empty driver list => no output for this printer
+
+    foreach my $driver (@drivers) {
+
+        @data = ppd_text_from_poid_and_driver($db, $poid, $driver);
+
+        # If there is some trouble with the ppd file,
+        # `ppd_text_from_poid_and_driver` will print a warning,
+        # so we can just skip the entry and continue.
+        next  if (!@data);
+
+        # create "make" directory
+        my $filename = $pr =~ s/[^a-zA-z0-9_.-]+//gr;
+        mkdir $filename;
+        # create "model" subdirectory
+        $filename .= "/";
+        $filename .= $model =~ s/[^a-zA-z0-9_.-]+//gr;
+        mkdir $filename;
+        # prepare filename
+        $filename .= "/$poid-$driver.ppd";
+
+        # write target file
+        open(filehandle, '>', "$filename")  or  die "error: $filename: failed to open target ppd file\n";
+        print filehandle @data;
+        close(filehandle);
+        print STDOUT "$pr\t$model\t$poid\t$driver\t$filename\n";
+
+    }
+
+}
+
+sub exportppds {
+
+    my ($match) = @_;
+
+    my ($onlyrecommended, $listreadymadeppds) = parse_cups_foomatic_conf();
+    my $db = Foomatic::DB->new();
+    $db->get_overview(1, 1 + $listreadymadeppds);
+
+    if ($opt_N) {
+        my $mce = MCE->new(max_workers => int($opt_N));
+        $mce->foreach($db->{'overview'}, sub { export_ppds_for_printer($db, $onlyrecommended, $match, $_); } );
+        die  if ($mce->status);
+    } else {
+        export_ppds_for_printer($db,$onlyrecommended, $match, $_)  foreach (@{$db->{'overview'}});
+    }
+
+}
+
 sub help {
     print <<HELP;
 
@@ -296,10 +372,12 @@ $progname -P <regexpr>
 $progname -p <printerid> [-d <driver>] [-w]
 $progname list
 $progname cat <CUPS PPD URI> [-w]
+$progname [-N <proc-count>] [-w] export
+$progname [-N <proc-count>] [-w] -P <regexpr> export
 $progname -h
 
  -A             : show all Printer ID's and compatible drivers
- -P <regexpr>   : show all Printer ID's whose names and model
+ -P <regexpr>   : show/export all Printer ID's whose names and model
                   matched by the RE.  For example:
                    -P HP will match all names with HP in them
  -p <printerid> : Printer ID
@@ -311,6 +389,11 @@ $progname -h
  cat <CUPS PPD URI> : Generate PPD file appropriate to the <CUPS PPD URI>.
                   Available CUPS PPD URIs are listed by 
                   "$progname list".
+ export         : Export all possible PPDs into make/model subdirectories
+                  (make/model names will be reduced to subset of aciss
+                  characters to avoid filesystem troubles)
+ -N <proc-count> : Parallelize PPD export by spawning the given
+                   number of processes (requires perl 'MCE' module)
  -w             : Generate PPD which is compatible with the CUPS PostScript
                   driver for Windows (GUI strings are limited to 39 
                   characters).

--- a/foomatic-ppdfile.in
+++ b/foomatic-ppdfile.in
@@ -64,7 +64,7 @@ if ($ARGV[0] =~ /^list$/i) {
 
 exit(0);
 
-sub cupslistppds {
+sub parse_cups_foomatic_conf {
 
     # Read configuration in /etc/cups/foomatic.conf
     my $conffilename;
@@ -96,6 +96,14 @@ sub cupslistppds {
 	}
 	close CONF;
     }
+
+    return ($onlyrecommended, $listreadymadeppds);
+
+}
+
+sub cupslistppds {
+
+    my ($onlyrecommended, $listreadymadeppds) = parse_cups_foomatic_conf();
 
     my $db = Foomatic::DB->new();
     $db->get_overview(1, 1 + $listreadymadeppds);


### PR DESCRIPTION
This adds an `export` subcommand to the `foomatic-ppdfile` script which can be used to generate multiple ppd files with one invocation.

### Motivation

I'm trying to package a collection of ppd files, generated from the foomatic database, for the [nixpkgs](https://repology.org/repository/nix_unstable) distribution.  Packaging efforts are currently discussed here https://github.com/NixOS/nixpkgs/pull/133537 .  Listing and generating ppd files is already possible with `foomatic-ppdfile` now, however, it is slow since the script parses the database with each invocation.

### Comments on the Implementation

One could also create a separate script to mass-export ppd files.  However, `foomatic-ppdfile` contains most of the code that is needed to enumerate and generate ppd files.  Hence a separate script would result in considerable code duplication.  In order to use the existing code, two commits move some code lines into separate subroutines so they can be used efficiently by the export mechanism in the third commit.

To speed up ppd file generation, the implementation parallelizes its duty with the MCE perl module.  Effectively, the script loads the database, then forks several processes that use the database object to iterate over each printer.  Parallel processing must be enabled with a command line switch; if not used, the MCE perl module isn't required.