### PR TITLE
Fix wget / curl auto-detection at configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,7 @@ AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
 
-# Checks for programs/directories which are used by Foomtic
+# Checks for programs/directories which are used by Foomatic
 
 SPOOLSEARCHPATH=/var/spool:/usr/spool/:/usr/local/spool:/usr/local/var/spool:/var/local/spool:/var/local
 LOGSEARCHPATH=/var/log:/usr/log:/usr/local/log:/usr/local/var/log:/var/local/log:/var/local

--- a/configure.ac
+++ b/configure.ac
@@ -68,10 +68,10 @@ fi
 AC_PATH_PROG(CAT,cat,CAT_NOT_FOUND,$BSB)
 AC_PATH_PROG(GS,gs,GHOSTSCRIPT_NOT_FOUND,$BSB)
 AC_PATH_PROG(A2PS,a2ps,A2PS_NOT_FOUND,$BSB)
-AC_PATH_PROG(WGET,wget,$BSB)
-AC_PATH_PROG(CURL,curl,$BSB)
-if test -z "$CURL" -a -z "$CURL" ; then
-	AC_MSG_ERROR("cannot find wget and curl.  You need to install at least one");
+AC_PATH_PROG(WGET,wget,,$BSB)
+AC_PATH_PROG(CURL,curl,,$BSB)
+if test -z "$WGET" -a -z "$CURL" ; then
+	AC_MSG_ERROR("cannot find wget or curl.  You need to install at least one");
 fi
 AC_PATH_PROG(PRINTF,printf,$BSB)dnl
 


### PR DESCRIPTION
1. Fix incorrect third argument in AC_PATH_PROG() macro to find wget or curl. Expected to be value if not found but was search path.
2. Fix mistake in test checking only curl (twice).
---
By the way, it seems same mistake is done for PRINTF just below.
