### PR TITLE
Use XML Make or Model for 1284DeviceID line if other info is missing

### DIFF
--- a/lib/Foomatic/DB.pm
+++ b/lib/Foomatic/DB.pm
@@ -4547,11 +4547,13 @@ sub deviceIDfromDBEntry {
     my $pnpmake;
     $pnpmake = $ieeemake or $pnpmake = $dat->{'general_mfg'} or 
 	$pnpmake = $dat->{'pnp_mfg'} or $pnpmake = $dat->{'par_mfg'} or
-	$pnpmake = $dat->{'usb_mfg'} or $pnpmake = "";
+	$pnpmake = $dat->{'usb_mfg'} or $pnpmake = $dat->{'make'} or
+	$pnpmake = "";
     my $pnpmodel;
     $pnpmodel = $ieeemodel or $pnpmodel = $dat->{'general_mdl'} or
 	$pnpmodel = $dat->{'pnp_mdl'} or $pnpmodel = $dat->{'par_mdl'} or
-	$pnpmodel = $dat->{'usb_mdl'} or $pnpmodel = "";
+	$pnpmodel = $dat->{'usb_mdl'} or $pnpmodel = $dat->{'model'} or
+	$pnpmodel = "";
     my $pnpcmd;
     $pnpcmd = $ieeecmd or $pnpcmd = $dat->{'general_cmd'} or 
 	$pnpcmd = $dat->{'pnp_cmd'} or $pnpcmd = $dat->{'par_cmd'} or


### PR DESCRIPTION
Windows 10 and 11 require 1284DeviceID to contain MFG and MDL elements, otherwise the shared printer would silently fail upon adding (or install endlessly, without any error).

If the XML file does not have `<autodetect>` section, use general `<make>` and `<model>` data to construct 1284DeviceID.

Closes #10 