### PR TITLE
Fix typo

### DIFF
--- a/lib/Foomatic/PPD.pm
+++ b/lib/Foomatic/PPD.pm
@@ -25,7 +25,7 @@ sub new {
     for $l (<PPD>) {
 	
 	# skip comments
-	next if ($l =~ m!^*%!);
+	next if ($l =~ m!^\*%!);
 	
 	# skip blank lines
 	next if ($l =~ m!^\s*$!);


### PR DESCRIPTION
The regular expression /^*%/ matches any line that contains a "%" character; however, the code's intention is to match lines that start with the characters "*%".