### PR TITLE
Fix usages of "open ... ||"

### DIFF
--- a/foomatic-cleanupdrivers.in
+++ b/foomatic-cleanupdrivers.in
@@ -20,11 +20,11 @@ $0 =~ m!/([^/]+)\s*$!;
 $progname = $1;
 
 # Read the directory with the driver's XML entries
-opendir DRIVERDIR, "$libdir/db/source/driver" ||
+opendir (DRIVERDIR, "$libdir/db/source/driver") or
     die "Cannot open driver XML directory!\n";
 my $driver;
 while ($driver = readdir(DRIVERDIR)) {
-    open DRIVERENTRY, "< $libdir/db/source/driver/$driver" || die "   Database entry for the driver $driver cannot be read!\n";
+    open (DRIVERENTRY, '<', "$libdir/db/source/driver/$driver") or die "   Database entry for the driver $driver cannot be read!\n";
     my @driverentryfield = <DRIVERENTRY>;
     close DRIVERENTRY;
     my $driverentry = join ('', @driverentryfield);

--- a/foomatic-compiledb.in
+++ b/foomatic-compiledb.in
@@ -168,7 +168,7 @@ sub spawn_child {
 			  (!$db->{'dat'}{'ppdfile'})));
 		@data = $db->getppd();
 	    }
-	    open OUTPUT, "> $filename" ||
+	    open (OUTPUT, '>', $filename) or
 		die "Cannot write $filename!";
 	    print OUTPUT join('', @data);
 	    close OUTPUT;

--- a/foomatic-nonumericalids.in
+++ b/foomatic-nonumericalids.in
@@ -63,7 +63,7 @@ for $printer (@{$db->{'overview'}}) {
 # Translation table to convert old numerical printer IDs to new
 # clear-text ones
 my $file = "$libdir/db/oldprinterids";
-open FILE, "> $file" ||
+open (FILE, '>', $file) or
     die "File $file cannot be written!\n";
 print FILE join('', @translationtable);
 close FILE;
@@ -71,7 +71,7 @@ print "   Wrote $file.\n";
 
 # List of old printer files to be removed from CVS
 $file = "oldprinterfiles";
-open FILE, "> $file" ||
+open (FILE, '>', $file) or
     die "File $file cannot be written!\n";
 print FILE join('', @oldidlist);
 close FILE;
@@ -79,7 +79,7 @@ print "   Wrote $file.\n";
 
 # List of files to be added to the CVS
 $file = "newprinterfiles";
-open FILE, "> $file" ||
+open (FILE, '>', $file) or
     die "File $file cannot be written!\n";
 print FILE join('', @newidlist);
 close FILE;
@@ -88,19 +88,19 @@ print "   Wrote $file.\n";
 # Scan through all files of the database and replace all references to
 # numerical printer IDs to the appriopriate new IDs
 my @xmlfiles;
-opendir DIR, "$libdir/db/source/printer" ||
+opendir (DIR, "$libdir/db/source/printer") or
     die "Cannot open printer XML directory!\n";
 while ($file = readdir(DIR)) {
     push(@xmlfiles, "printer/$file") if $file =~ /^[^\.].*\.xml$/;
 }
 closedir DIR;
-opendir DIR, "$libdir/db/source/driver" ||
+opendir (DIR, "$libdir/db/source/driver") or
     die "Cannot open driver XML directory!\n";
 while ($file = readdir(DIR)) {
     push(@xmlfiles, "driver/$file") if $file =~ /^[^\.].*\.xml$/;
 }
 closedir DIR;
-opendir DIR, "$libdir/db/source/opt" ||
+opendir (DIR, "$libdir/db/source/opt") or
     die "Cannot open option XML directory!\n";
 while ($file = readdir(DIR)) {
     push(@xmlfiles, "opt/$file") if $file =~ /^[^\.].*\.xml$/;
@@ -112,7 +112,7 @@ my $chfiles = 0;
 my @chfilelist;
 for $file (@xmlfiles) {
     print "Processing $file";
-    open FILE, "< $libdir/db/source/$file" ||
+    open (FILE, '<', "$libdir/db/source/$file") or
 	die "Database entry $file cannot be read!\n";
     my @lines = <FILE>;
     close FILE;
@@ -128,7 +128,7 @@ for $file (@xmlfiles) {
     }
     print "\n";
     next if !$ch;
-    open FILE, "> $libdir/db/source/$file" ||
+    open (FILE, '>', "$libdir/db/source/$file") or
 	die "Database entry $file cannot be written!\n";
     print FILE join('', @lines);
     close FILE;
@@ -139,7 +139,7 @@ for $file (@xmlfiles) {
 
 # List of files changed in CVS
 $file = "changedfiles";
-open FILE, "> $file" ||
+open (FILE, '>', $file) or
     die "File $file cannot be written!\n";
 print FILE join('', @oldidlist, @chfilelist);
 close FILE;

--- a/foomatic-preferred-driver.in
+++ b/foomatic-preferred-driver.in
@@ -59,7 +59,7 @@ for $printer (@{$db->{'overview'}}) {
 	print ": @sorted --> $sorted[0]\n";
 	$printer->{'driver'} = $sorted[0];
     }
-    open PRINTERENTRY, "< $libdir/db/source/printer/$printer->{'id'}.xml" || die "   Database entry for the printer $printer->{'make'} $printer->{'model'} ($printer->{'id'}) cannot be read!\n";
+    open (PRINTERENTRY, '<', "$libdir/db/source/printer/$printer->{'id'}.xml") or die "   Database entry for the printer $printer->{'make'} $printer->{'model'} ($printer->{'id'}) cannot be read!\n";
     my  @printerentryfield = <PRINTERENTRY>;
     close PRINTERENTRY;
 	
@@ -80,7 +80,7 @@ for $printer (@{$db->{'overview'}}) {
 	$printerentry =~
 	  s!</model>!</model>\n  <driver>$printer->{'driver'}</driver>!sg;
     }
-    open PRINTERENTRY, "> $libdir/db/source/printer/$printer->{'id'}.xml" || die "   Database entry for the printer $printer->{'make'} $printer->{'model'} ($printer->{'id'}) cannot be written!\n";
+    open (PRINTERENTRY, '>', "$libdir/db/source/printer/$printer->{'id'}.xml") or die "   Database entry for the printer $printer->{'make'} $printer->{'model'} ($printer->{'id'}) cannot be written!\n";
     print PRINTERENTRY $printerentry;
     close PRINTERENTRY;
 }

--- a/foomatic-printjob.in
+++ b/foomatic-printjob.in
@@ -121,14 +121,14 @@ if (!defined($in_config->{'spooler'})) {
 if (defined($opt_S)) {
     if ($> == 0) { # Program invoked as "root"?
 	# Set system default spooler
-	open DEFAULTFILE, "> $sysdeps->{'foo-etc'}/defaultspooler" ||
+	open (DEFAULTFILE, '>', "$sysdeps->{'foo-etc'}/defaultspooler") or
 	    die "Cannot write $sysdeps->{'foo-etc'}/defaultspooler!\n";
 	print DEFAULTFILE "$in_config->{'spooler'}\n";
 	close DEFAULTFILE;
 	exit 0;
     } else {
 	# Set personal default spooler
-	open DEFAULTFILE, "> $ENV{'HOME'}/.defaultspooler" ||
+	open (DEFAULTFILE, '>', "$ENV{'HOME'}/.defaultspooler") or
 	    die "Cannot write $ENV{'HOME'}/.defaultspooler!\n";
 	print DEFAULTFILE "$in_config->{'spooler'}\n";
 	close DEFAULTFILE;
@@ -315,7 +315,7 @@ sub query_lprng {
     if (defined($config->{'queue'})) {
 	$queue = " -P $config->{'queue'}";
     }
-    open LPQOUTPUT, "$sysdeps->{'lpd-lpq'}$queue @ARGV |" || return 1;
+    open (LPQOUTPUT, "$sysdeps->{'lpd-lpq'}$queue @ARGV |") or return 1;
     my @lpqoutput = <LPQOUTPUT>;
     close LPQOUTPUT;
     # Filter the output
@@ -643,7 +643,7 @@ sub print_pdq {
 	    my @job_contents = <STDIN>;
 	    my $i;
 	    for ($i = 0; $i < $num_copies; $i++) {
-		open PIPE, "| $commandline" || 
+		open (PIPE, "| $commandline") or
 		    die "Could not launch printing command!\n";
 		print PIPE @job_contents;
 		close PIPE;
@@ -721,7 +721,7 @@ sub query_pdq {
 
     # Read in the names of all job status files in ~/.printjobs/
     my @jobnumbers = ();
-    opendir PJDIR, "$ENV{'HOME'}/.printjobs" || 
+    opendir (PJDIR, "$ENV{'HOME'}/.printjobs") or
 	return 0;  # No ~/.printjobs/ directory ==> no jobs
     while ($filename = readdir(PJDIR)) {
 	if ($filename =~ m!^([0-9][0-9][0-9]).status$!) {
@@ -877,7 +877,7 @@ sub remove_pdq {
 
     # Read in the names of all job status files in ~/.printjobs/
     my @jobnumbers = ();
-    opendir PJDIR, "$ENV{'HOME'}/.printjobs" || 
+    opendir (PJDIR, "$ENV{'HOME'}/.printjobs") or
 	return 0;  # No ~/.printjobs/ directory ==> no jobs
     while ($filename = readdir(PJDIR)) {
 	if ($filename =~ m!^([0-9][0-9][0-9]).status$!) {

--- a/foomatic-replaceoldprinterids.in
+++ b/foomatic-replaceoldprinterids.in
@@ -38,7 +38,7 @@ $rightpattern = $opt_r if defined($opt_r);
 my %idhash;
 my $idtable = "$libdir/db/oldprinterids";
 $idtable = $opt_t if $opt_t;
-open IDTABLE, "< $idtable" ||
+open (IDTABLE, '<', $idtable) or
     die "File $idtable cannot be read!\n";
 while (<IDTABLE>) {
     if (/^\s*(\S+)\s+(\S+)\s*$/) {
@@ -52,7 +52,7 @@ my $chfiles = 0;
 my @chfilelist;
 while (my $file = shift @ARGV) {
     print "Processing $file";
-    open FILE, "< $file" ||
+    open (FILE, '<', $file) or
 	die "File $file cannot be read!\n";
     my @lines = <FILE>;
     close FILE;
@@ -68,7 +68,7 @@ while (my $file = shift @ARGV) {
     }
     print "\n";
     next if !$ch;
-    open FILE, "> $file" ||
+    open (FILE, '>', $file) or
 	die "File $file cannot be written!\n";
     print FILE join('', @lines);
     close FILE;
@@ -79,7 +79,7 @@ while (my $file = shift @ARGV) {
 
 # List of files changed
 $file = "modifiedfiles";
-open FILE, "> $file" ||
+open (FILE, '>', $file) or
     die "File $file cannot be written!\n";
 print FILE join('', @oldidlist, @chfilelist);
 close FILE;


### PR DESCRIPTION
Due to operator precedence, Perl treats:

| open FH, "> $file" || die 'Error';

as:

| open FH, ("> $file" || die 'Error');

which will always evaluate as:

| open FH, "> $file";

This change fixes those occurences, additionally using three-argument open().